### PR TITLE
Add Arbitrum Networks

### DIFF
--- a/hardhat/erc20-token/hardhat.config.ts
+++ b/hardhat/erc20-token/hardhat.config.ts
@@ -19,5 +19,15 @@ module.exports = {
       url: "https://rpc.sepolia.org",
       chainId: 11155111,
     },
+    arbitrumOne: {
+      accounts: [process.env.PK],
+      url: 'https://arb1.arbitrum.io/rpc',
+      chainId: 42161
+    },
+    arbitrumSepolia: {
+      accounts: [process.env.PK],
+      url: 'https://sepolia-rollup.arbitrum.io/rpc',
+      chainId: 421614
+    },
   },
 };


### PR DESCRIPTION
In this PR we're adding the Arbitrum One (mainnet) and Arbitrum Sepolia (testnet) networks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `arbitrumOne` network.
  - Added support for the `arbitrumSepolia` network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->