### PR TITLE
chore: add presale option on the mobile navbar

### DIFF
--- a/apps/web/components/dialogs/session/session-button.tsx
+++ b/apps/web/components/dialogs/session/session-button.tsx
@@ -65,7 +65,7 @@ export function SessionButton() {
                 <>
                   <li>
                     <Link href="/bitcash-bitlauncher/presale" className="cursor-pointer">
-                      Presale
+                      Pre Sale
                     </Link>
                   </li>
                   {appConfig.features.wallet ? (

--- a/apps/web/components/layout/header/nav-links.tsx
+++ b/apps/web/components/layout/header/nav-links.tsx
@@ -42,6 +42,14 @@ export function NavLinks({
       disabled: !bitcashAccount,
     },
     {
+      id: 'presale',
+      href: '/bitcash-bitlauncher/presale',
+      text: 'Pre Sale',
+      mobile: true,
+      action: null,
+      disabled: !bitcashAccount,
+    },
+    {
       id: 'about',
       href: '/about/about-bitlauncher',
       text: dict.nav.about,


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a 'Pre Sale' option in the mobile navigation bar and update the session button link text to 'Pre Sale'.

New Features:
- Add a 'Pre Sale' option to the mobile navigation bar, linking to the presale page.

Enhancements:
- Update the text label from 'Presale' to 'Pre Sale' in the session button link.

<!-- Generated by sourcery-ai[bot]: end summary -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the label for the link from "Presale" to "Pre Sale."
	- Introduced a new navigation link for the "Pre Sale" section, enhancing user access to presale information based on account status.

- **Bug Fixes**
	- No bug fixes were included in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->