### PR TITLE
Revert "impr(web): seo sitemap (#422)"

### DIFF
--- a/apps/web/app/(routes)/[lang]/[project]/auction/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/[project]/auction/sitemap.ts
@@ -1,21 +1,25 @@
+import { getDictionary } from '@/dictionaries'
 import { AVAILABLE_LANGS } from '@/lib/config'
+import { getProjects } from '@/lib/projects'
+import type { ProjectPageProps } from '@/types/routing.type'
 import type { MetadataRoute } from 'next'
-import { generateStaticParams } from '../page'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const projects = await generateStaticParams()
+export default async function sitemap({
+  params,
+}: ProjectPageProps): Promise<MetadataRoute.Sitemap> {
+  const dict = await getDictionary(params.lang)
+  const projects = await getProjects(dict)
 
-  return projects.map((item) => ({
-    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${item.project}/auction`,
+  return projects.map((project) => ({
+    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${project.slug}/auction`,
     lastModified: new Date(),
-    changeFrequency: 'yearly',
     priority: 0.9,
     alternates: {
       // ? e.g.: { 'en': 'https://example.com/en/...', 'es': 'https://example.com/es/...', ... }
       languages: Object.fromEntries(
         AVAILABLE_LANGS.map((lang) => [
           lang,
-          `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/${item.project}/auction`,
+          `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/${project.slug}/presale`,
         ]),
       ),
     },

--- a/apps/web/app/(routes)/[lang]/[project]/page.tsx
+++ b/apps/web/app/(routes)/[lang]/[project]/page.tsx
@@ -169,13 +169,3 @@ const DynamicCtaButton = dynamic(
     loading: () => <Button variant="accent">Get Whitelisted</Button>,
   },
 )
-
-
-export async function generateMetadata({ params }: ProjectPageProps) {
-  const dict = await getDictionary(params.lang)
-  const project = await getProjectBySlug(params.project, dict)
-  return {
-    title: project?.title,
-    description: project?.pitch,
-  }
-}

--- a/apps/web/app/(routes)/[lang]/[project]/presale/page.tsx
+++ b/apps/web/app/(routes)/[lang]/[project]/presale/page.tsx
@@ -81,10 +81,3 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
     </div>
   )
 }
-
-export async function generateMetadata({ params }: ProjectPageProps) {
-  return {
-    title: `Presale - ${params.project}`,
-    description: `Participate in the presale for ${params.project}. Contribute and be a part of the project before it launches.`,
-  }
-}

--- a/apps/web/app/(routes)/[lang]/[project]/presale/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/[project]/presale/sitemap.ts
@@ -3,22 +3,23 @@ import { AVAILABLE_LANGS } from '@/lib/config'
 import { getProjects } from '@/lib/projects'
 import type { ProjectPageProps } from '@/types/routing.type'
 import type { MetadataRoute } from 'next'
-import { generateStaticParams } from '../page'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const projects = await generateStaticParams()
+export default async function sitemap({
+  params,
+}: ProjectPageProps): Promise<MetadataRoute.Sitemap> {
+  const dict = await getDictionary(params.lang)
+  const projects = await getProjects(dict)
 
-  return projects.map((item) => ({
-    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${item.project}/presale`,
+  return projects.map((project) => ({
+    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${project.slug}/presale`,
     lastModified: new Date(),
-    changeFrequency: 'yearly',
     priority: 0.9,
     alternates: {
       // ? e.g.: { 'en': 'https://example.com/en/...', 'es': 'https://example.com/es/...', ... }
       languages: Object.fromEntries(
         AVAILABLE_LANGS.map((lang) => [
           lang,
-          `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/${item.project}/presale`,
+          `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/${project.slug}/presale`,
         ]),
       ),
     },

--- a/apps/web/app/(routes)/[lang]/[project]/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/[project]/sitemap.ts
@@ -1,21 +1,25 @@
+import { getDictionary } from '@/dictionaries'
 import { AVAILABLE_LANGS } from '@/lib/config'
+import { getProjects } from '@/lib/projects'
+import type { ProjectPageProps } from '@/types/routing.type'
 import type { MetadataRoute } from 'next'
-import { generateStaticParams } from './page'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const projects = await generateStaticParams()
+export default async function sitemap({
+  params,
+}: ProjectPageProps): Promise<MetadataRoute.Sitemap> {
+  const dict = await getDictionary(params.lang)
+  const projects = await getProjects(dict)
 
-  return projects.map((item) => ({
-    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${item.project}`,
+  return projects.map((project) => ({
+    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${project.slug}`,
     lastModified: new Date(),
-    changeFrequency: 'yearly',
-    priority: 0.7,
+    priority: 0.9,
     alternates: {
       // ? e.g.: { 'en': 'https://example.com/en/...', 'es': 'https://example.com/es/...', ... }
       languages: Object.fromEntries(
         AVAILABLE_LANGS.map((lang) => [
           lang,
-          `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/${item.project}`,
+          `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/${project.slug}`,
         ]),
       ),
     },

--- a/apps/web/app/(routes)/[lang]/about/about-bitlauncher/page.tsx
+++ b/apps/web/app/(routes)/[lang]/about/about-bitlauncher/page.tsx
@@ -62,7 +62,7 @@ const content: AboutBitlauncherPageContent = {
 }
 
 export const metadata: Metadata = {
-  title: 'About Bitlauncher - AI & Cryptocurrency Launchpad',
+  title: 'Bitlauncher',
   description:
-    'Discover Bitlauncher, the pioneering launchpad dedicated to transforming AI and cryptocurrency. Join the AI/Web3 revolution today!',
+    'Be part of the intelligent future and join the Ai/Web3 revolution now!',
 }

--- a/apps/web/app/(routes)/[lang]/about/about-bitlauncher/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/about/about-bitlauncher/sitemap.ts
@@ -1,7 +1,10 @@
 import { AVAILABLE_LANGS } from '@/lib/config'
+import type { CommonPageProps } from '@/types/routing.type'
 import type { MetadataRoute } from 'next'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+export default async function sitemap({
+  params,
+}: CommonPageProps): Promise<MetadataRoute.Sitemap> {
   return [
     {
       url: `https://${process.env.NEXT_PUBLIC_APP_URL}/about/about-bitlauncher`,

--- a/apps/web/app/(routes)/[lang]/blog/[category]/[slug]/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/blog/[category]/[slug]/sitemap.ts
@@ -1,24 +1,34 @@
 import { AVAILABLE_LANGS } from '@/lib/config'
-import { getAllArticles } from '@/services/datocms/datocms-all-articles.service'
+import { getBlogCategoryLandingData } from '@/services/datocms'
 import type { MetadataRoute } from 'next'
+import type { ArticlePageProps } from './page'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const articles = await getAllArticles()
-  if (!articles) return []
- 
-  return articles.flatMap((item) =>
-    item.articles.map((article) => ({
-      url: `https://${process.env.NEXT_PUBLIC_APP_URL}/blog/${item.category}/${article.slug}`,
-      lastModified: article._publishedAt,
-      priority: 0.6,
-      alternates: {
-        languages: Object.fromEntries(
-          AVAILABLE_LANGS.map((lang) => [
-            lang,
-            `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/blog/${item.category}/${article.slug}`,
-          ]),
-        ),
-      },
-    })),
-  )
+export default async function sitemap(
+  props: ArticlePageProps,
+): Promise<MetadataRoute.Sitemap> {
+  const {
+    params: { lang, category },
+  } = props
+  const data = await getBlogCategoryLandingData(lang, category)
+  if (!data) return []
+
+  const { sections } = data
+  if (!sections) return []
+
+  const slugs = sections.map((section) => section.slug)
+
+  return slugs.map((slug) => ({
+    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/blog/${category}/${slug}`,
+    lastModified: new Date(),
+    priority: 0.5,
+    alternates: {
+      // ? e.g.: { 'en': 'https://example.com/en/...', 'es': 'https://example.com/es/...', ... }
+      languages: Object.fromEntries(
+        AVAILABLE_LANGS.map((lang) => [
+          lang,
+          `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/blog/${category}/${slug}`,
+        ]),
+      ),
+    },
+  }))
 }

--- a/apps/web/app/(routes)/[lang]/blog/[category]/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/blog/[category]/sitemap.ts
@@ -1,14 +1,24 @@
 import { AVAILABLE_LANGS } from '@/lib/config'
-import { getAllArticles } from '@/services/datocms/datocms-all-articles.service'
+import { getArticleSections } from '@/services/datocms'
 import type { MetadataRoute } from 'next'
+import type { CategoryPageProps } from './page'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const articles = await getAllArticles()
-  if (!articles) return []
+export default async function sitemap(
+  props: CategoryPageProps,
+): Promise<MetadataRoute.Sitemap> {
+  const {
+    params: { lang },
+  } = props
+  let sections = []
+  try {
+    sections = await getArticleSections(lang)
+  } catch (error) {
+    return []
+  }
 
-  const categoryUrls = [...new Set(articles.map((article) => article.category))]
-  return categoryUrls.map((category) => ({
-    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/blog/${category}`,
+  const categories = sections.map((section) => section.slug)
+  return categories.map((category) => ({
+    url: `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/blog/${category}`,
     lastModified: new Date(),
     priority: 0.7,
     alternates: {

--- a/apps/web/app/(routes)/[lang]/blog/page.tsx
+++ b/apps/web/app/(routes)/[lang]/blog/page.tsx
@@ -33,7 +33,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
 export async function generateMetadata({
   params,
 }: BlogPageProps): Promise<Metadata> {
-  const pageSeo = await getPageSeoText('bitlauncher')
+  const pageSeo = await getPageSeoText('home')
   const seoData = {
     title: pageSeo.pageSeo?.title || '',
     description: pageSeo.pageSeo?.description || '',

--- a/apps/web/app/(routes)/[lang]/blog/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/blog/sitemap.ts
@@ -1,7 +1,10 @@
 import { AVAILABLE_LANGS } from '@/lib/config'
+import type { CommonPageProps } from '@/types/routing.type'
 import type { MetadataRoute } from 'next'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+export default async function sitemap({
+  params,
+}: CommonPageProps): Promise<MetadataRoute.Sitemap> {
   return [
     {
       url: `https://${process.env.NEXT_PUBLIC_APP_URL}/blog`,

--- a/apps/web/app/(routes)/[lang]/learn/security/page.tsx
+++ b/apps/web/app/(routes)/[lang]/learn/security/page.tsx
@@ -31,7 +31,7 @@ export default async function SecurityTips({ params }: CommonPageProps) {
 }
 
 export const metadata: Metadata = {
-  title: 'Top Security Tips for a Safer Digital Experience',
+  title: 'Security Tips | Bitlauncher',
   description:
-    'Discover essential security tips to protect yourself online. Join the AI/Web3 revolution and stay ahead with our expert advice.',
+    'Be part of the intelligent future and join the Ai/Web3 revolution now!',
 }

--- a/apps/web/app/(routes)/[lang]/legal/privacy/page.tsx
+++ b/apps/web/app/(routes)/[lang]/legal/privacy/page.tsx
@@ -14,7 +14,7 @@ export default async function PrivacyPolicy({ params }: CommonPageProps) {
 }
 
 export const metadata: Metadata = {
-  title: 'Privacy Policy',
+  title: 'Privacy Policy | Bitlauncher',
   description:
     'Read our Privacy Policy to understand how we protect and manage your data in our crypto launchpad application.',
 }

--- a/apps/web/app/(routes)/[lang]/legal/terms/page.tsx
+++ b/apps/web/app/(routes)/[lang]/legal/terms/page.tsx
@@ -14,7 +14,7 @@ export default async function PrivacyPolicy({ params }: CommonPageProps) {
 }
 
 export const metadata: Metadata = {
-  title: 'Terms of Service',
+  title: 'Privacy Policy | Bitlauncher',
   description:
-    'Review our Terms of Service to understand the rules and regulations for using our crypto launchpad application.',
+    'Read our Privacy Policy to understand how we protect and manage your data in our crypto launchpad application.',
 }

--- a/apps/web/app/(routes)/[lang]/sitemap.ts
+++ b/apps/web/app/(routes)/[lang]/sitemap.ts
@@ -1,12 +1,14 @@
 import { AVAILABLE_LANGS } from '@/lib/config'
+import type { CommonPageProps } from '@/types/routing.type'
 import type { MetadataRoute } from 'next'
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+export default async function sitemap({
+  params,
+}: CommonPageProps): Promise<MetadataRoute.Sitemap> {
   return [
     {
       url: `https://${process.env.NEXT_PUBLIC_APP_URL}`,
       lastModified: new Date(),
-      changeFrequency: 'yearly',
       priority: 1,
       alternates: {
         // ? e.g.: { 'en': 'https://example.com/en/...', 'es': 'https://example.com/es/...', ... }
@@ -14,62 +16,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
           AVAILABLE_LANGS.map((lang) => [
             lang,
             `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}`,
-          ]),
-        ),
-      },
-    },
-    {
-      url: `https://${process.env.NEXT_PUBLIC_APP_URL}/blog`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.8,
-      alternates: {
-        languages: Object.fromEntries(
-          AVAILABLE_LANGS.map((lang) => [
-            lang,
-            `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/blog`,
-          ]),
-        ),
-      },
-    },
-    {
-      url: `https://${process.env.NEXT_PUBLIC_APP_URL}/whitepaper`,
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
-      priority: 0.6,
-      alternates: {
-        languages: Object.fromEntries(
-          AVAILABLE_LANGS.map((lang) => [
-            lang,
-            `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/whitepaper`,
-          ]),
-        ),
-      },
-    },
-    {
-      url: `https://${process.env.NEXT_PUBLIC_APP_URL}/learn/security`,
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
-      priority: 0.6,
-      alternates: {
-        languages: Object.fromEntries(
-          AVAILABLE_LANGS.map((lang) => [
-            lang,
-            `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/learn/security`,
-          ]),
-        ),
-      },
-    },
-    {
-      url: `https://${process.env.NEXT_PUBLIC_APP_URL}/about/about-bitlauncher`,
-      lastModified: new Date(),
-      changeFrequency: 'yearly',
-      priority: 0.6,
-      alternates: {
-        languages: Object.fromEntries(
-          AVAILABLE_LANGS.map((lang) => [
-            lang,
-            `https://${process.env.NEXT_PUBLIC_APP_URL}/${lang}/about/about-bitlauncher`,
           ]),
         ),
       },

--- a/apps/web/app/(routes)/[lang]/wallet/page.tsx
+++ b/apps/web/app/(routes)/[lang]/wallet/page.tsx
@@ -43,9 +43,9 @@ export default function WalletPage() {
 }
 
 export const metadata: Metadata = {
-  title: 'Wallet Balances',
+  title: 'Wallet | Bitlauncher',
   description:
-    'Your balances on the Bitlauncher | Bitcash  ecosystem. Connect your Bitcash and EVM wallets',
+    'Be part of the intelligent future and join the Ai/Web3 revolution now!',
 }
 
 function BalancesCard() {

--- a/apps/web/app/(routes)/[lang]/whitepaper/page.tsx
+++ b/apps/web/app/(routes)/[lang]/whitepaper/page.tsx
@@ -10,6 +10,6 @@ export default async function WhitepaperPage() {
 }
 
 export const metadata: Metadata = {
-  title: 'Comprehensive Whitepaper',
-  description: 'Explore the detailed whitepaper of Bitlauncher, covering all aspects of our innovative platform and technology.',
+  title: 'Bitlauncher',
+  description: 'Whitepaper',
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -26,23 +26,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly',
       priority: 0.7,
     },
-    {
-      url: 'https://bitlauncher.ai/whitepaper',
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.7,
-    },
-    {
-      url: 'https://bitlauncher.ai/legal/terms',
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
-    {
-      url: 'https://bitlauncher.ai/legal/privacy',
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
   ]
 }

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext", "webworker"],
-    "target": "ES6",
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,


### PR DESCRIPTION
This reverts commit 2358f2f1a3d33eba51bc3fe817aa8fb7940cea1b.

## Summary by Sourcery

Revert the previous changes made to the SEO sitemap configuration, restoring the original sitemap structure and metadata settings.

Enhancements:
- Restore the original sitemap structure and metadata settings across various routes.

Documentation:
- Update metadata titles and descriptions to reflect the original content across multiple pages.

Chores:
- Revert the previous commit that modified the SEO sitemap configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced sitemap generation to support dynamic language parameters and project slugs.
	- Updated metadata for various pages to reflect new branding and messaging.

- **Bug Fixes**
	- Improved error handling in sitemap functions to ensure robustness.

- **Documentation**
	- Metadata titles and descriptions updated across multiple pages for clarity and branding.

- **Chores**
	- Removed outdated sitemap entries for improved simplicity and focus on core URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->